### PR TITLE
Added default WP 5.5 lazyloading.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,15 @@
 # Change log
 
+## 1.4.1 - In development
+
+### Added
+
+- Added default WP 5.5 lazyloading.
+
 ## [[1.4.0]](https://github.com/lightspeeddevelopment/lsx-blog-customizer/releases/tag/1.4.0) - Unreleased
 
 ### Added
+
 - Removed the CMB and UIX vendors.
 - Added a 2 columns layout option for the blog.
 - Fixed spacing for the archive layouts.

--- a/classes/class-lsx-blog-customizer-terms.php
+++ b/classes/class-lsx-blog-customizer-terms.php
@@ -134,10 +134,6 @@ if ( ! class_exists( 'LSX_Blog_Customizer_Terms' ) ) {
 						} else {
 							$image = '';
 						}
-
-						if ( ! empty( $image ) ) {
-							$image = apply_filters( 'lsx_to_lazyload_filter_images', '<img src="' . $image . '" class="img-responsive">' );
-						}
 					} else {
 						$image = '';
 					}

--- a/classes/class-lsx-blog-customizer-widget-posts.php
+++ b/classes/class-lsx-blog-customizer-widget-posts.php
@@ -115,13 +115,7 @@ if ( ! class_exists( 'LSX_Blog_Customizer_Widget_Posts' ) ) {
 			if ( isset( $this->args ) && isset( $this->args['lsx_mm'] ) ) {
 				$shotcode_atts['lsx_mm'] = true;
 			}
-			if ( 'true' === $carousel || true === $carousel ) {
-				add_filter( 'lsx_lazyload_slider_images', array( $this, 'lazyload_slider_images' ), 10, 5 );
-			}
 			lsx_blog_customizer_posts( $shotcode_atts );
-			if ( 'true' === $carousel || true === $carousel ) {
-				remove_filter( 'lsx_lazyload_slider_images', array( $this, 'lazyload_slider_images' ), 10, 5 );
-			}
 			if ( $button_text && $title_link ) {
 				echo wp_kses_post( '<p class="text-center lsx-blog-customizer-posts-archive-link-wrap"><span class="lsx-blog-customizer-posts-archive-link">' . $link_btn_open . $button_text . ' <i class="fa fa-angle-right"></i>' . $link_btn_close . '</span></p>' );
 			}
@@ -311,33 +305,6 @@ if ( ! class_exists( 'LSX_Blog_Customizer_Widget_Posts' ) ) {
 			<?php
 		}
 
-		/**
-		 * Applies the lazy loading if needed.
-		 *
-		 * @param String $img
-		 * @return void
-		 */
-		public function lazyload_slider_images( $img, $post_thumbnail_id, $size, $srcset, $image_url ) {
-			$lazyload = true;
-			if ( ! apply_filters( 'lsx_lazyload_is_enabled', true ) ) {
-				$lazyload = false;
-			}
-			$lazy_img = '';
-			if ( true === $lazyload && '' !== $img ) {
-				$temp_lazy = wp_get_attachment_image_src( $post_thumbnail_id, $size );
-				if ( ! empty( $temp_lazy ) ) {
-					$lazy_img = $temp_lazy[0];
-				}
-				$img = '<img alt="' . the_title_attribute( 'echo=0' ) . '" class="attachment-responsive wp-post-image lsx-responsive" ';
-				if ( $srcset ) {
-					$img .= 'data-lazy="' . $lazy_img . '" srcset="' . esc_attr( $image_url ) . '" ';
-				} else {
-					$img .= 'data-lazy="' . esc_url( $image_url ) . '" ';
-				}
-				$img .= '/>';
-			}
-			return $img;
-		}
 	}
 
 	/**

--- a/classes/class-lsx-blog-customizer-widget-terms.php
+++ b/classes/class-lsx-blog-customizer-widget-terms.php
@@ -88,9 +88,6 @@ if ( ! class_exists( 'LSX_Blog_Customizer_Widget_Terms' ) ) {
 				echo '<p class="tagline text-center">' . esc_html( $tagline ) . '</p>';
 			}
 
-			if ( 'true' === $carousel || true === $carousel ) {
-				add_filter( 'lsx_lazyload_slider_images', array( $this, 'lazyload_slider_images' ), 10, 5 );
-			}
 			lsx_blog_customizer_terms(
 				array(
 					'taxonomy'   => $taxonomy,
@@ -105,9 +102,6 @@ if ( ! class_exists( 'LSX_Blog_Customizer_Widget_Terms' ) ) {
 					'carousel'   => $carousel,
 				)
 			);
-			if ( 'true' === $carousel || true === $carousel ) {
-				remove_filter( 'lsx_lazyload_slider_images', array( $this, 'lazyload_slider_images' ), 10, 5 );
-			}
 
 			if ( $button_text && $title_link ) {
 				echo wp_kses_post( '<p class="text-center lsx-blog-customizer-terms-archive-link-wrap"><span class="lsx-blog-customizer-terms-archive-link">' . $link_btn_open . $button_text . ' <i class="fa fa-angle-right"></i>' . $link_btn_close . '</span></p>' );
@@ -279,33 +273,6 @@ if ( ! class_exists( 'LSX_Blog_Customizer_Widget_Terms' ) ) {
 				<label for="<?php echo esc_attr( $this->get_field_id( 'carousel' ) ); ?>"><?php esc_html_e( 'Carousel', 'lsx-blog-customizer' ); ?></label>
 			</p>
 			<?php
-		}
-		/**
-		 * Applies the lazy loading if needed.
-		 *
-		 * @param String $img
-		 * @return void
-		 */
-		public function lazyload_slider_images( $img, $post_thumbnail_id, $size, $srcset, $image_url ) {
-			$lazyload = true;
-			if ( ! apply_filters( 'lsx_lazyload_is_enabled', true ) ) {
-				$lazyload = false;
-			}
-			$lazy_img = '';
-			if ( true === $lazyload && '' !== $img ) {
-				$temp_lazy = wp_get_attachment_image_src( $post_thumbnail_id, $size );
-				if ( ! empty( $temp_lazy ) ) {
-					$lazy_img = $temp_lazy[0];
-				}
-				$img = '<img alt="' . the_title_attribute( 'echo=0' ) . '" class="attachment-responsive wp-post-image lsx-responsive" ';
-				if ( $srcset ) {
-					$img .= 'data-lazy="' . $lazy_img . '" srcset="' . esc_attr( $image_url ) . '" ';
-				} else {
-					$img .= 'data-lazy="' . esc_url( $image_url ) . '" ';
-				}
-				$img .= '/>';
-			}
-			return $img;
 		}
 	}
 


### PR DESCRIPTION
### Changes

Added support for native Lazy-loading images on WordPress 5.5 version.

### Benefits

- Support for WP 5.5 features.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

https://github.com/lightspeeddevelopment/lsx/issues/425

### Changelog Entry

#### Added
- Added support for native Lazy-loading images on WordPress 5.5 version.
